### PR TITLE
Add initial PWA scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # santadicas
-Criação do aplicativo Santa Dicas.
+
+Aplicativo simples baseado no PRD do Santa Dicas. Este projeto demonstra um PWA para exibir um cardápio digital e receber pedidos.
+
+## Estrutura
+- **server/**: servidor Express que fornece a API e distribui os arquivos estáticos.
+- **client/**: PWA mínimo com serviço de cache offline.
+
+## Uso
+1. Instale as dependências (é necessário Node.js):
+   ```bash
+   cd server && npm install
+   ```
+2. Inicie o servidor:
+   ```bash
+   npm start
+   ```
+3. Acesse `http://localhost:3000` no navegador para visualizar o cardápio.
+
+Este projeto é um ponto de partida e deve ser expandido conforme os requisitos do PRD.

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,29 @@
+async function loadMenu() {
+  const res = await fetch('/api/menu');
+  const items = await res.json();
+  const container = document.getElementById('menu');
+  container.innerHTML = items.map(item => `
+    <div class="item">
+      <h3>${item.name} - R$ ${item.price.toFixed(2)}</h3>
+      <p>${item.description}</p>
+      <button onclick='orderItem(${JSON.stringify(item)})'>Pedir</button>
+    </div>`).join('');
+}
+
+async function orderItem(item) {
+  const res = await fetch('/api/order', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ item })
+  });
+  const data = await res.json();
+  alert('Status do pedido: ' + data.status);
+}
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}
+
+loadMenu();

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Santa Dicas</title>
+  <link rel="manifest" href="manifest.json" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Santa Dicas</h1>
+  <div id="menu"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/client/manifest.json
+++ b/client/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Santa Dicas",
+  "short_name": "SantaDicas",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "PWA para gerenciamento de pedidos",
+  "icons": []
+}

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -1,0 +1,14 @@
+const CACHE_NAME = 'santadicas-cache-v1';
+const urlsToCache = ['/', '/app.js', '/style.css'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/client/style.css
+++ b/client/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 1em; }
+.item { border-bottom: 1px solid #ccc; padding: 0.5em 0; }
+button { padding: 0.3em 0.6em; }

--- a/server/menu.json
+++ b/server/menu.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "category": "Burgers",
+    "name": "Cheeseburger",
+    "price": 15.5,
+    "description": "Delicious cheeseburger with fries",
+    "image": "burger.jpg"
+  },
+  {
+    "id": 2,
+    "category": "Drinks",
+    "name": "Soda",
+    "price": 5.0,
+    "description": "Cold soda can",
+    "image": "soda.jpg"
+  }
+]

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "santadicas-server",
+  "version": "0.1.0",
+  "description": "Backend for Santa Dicas PWA",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.2"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,33 @@
+import express from 'express';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import { readFileSync, writeFileSync } from 'fs';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(bodyParser.json());
+app.use(express.static('../client'));
+
+const menuPath = './menu.json';
+let menu = [];
+try {
+  menu = JSON.parse(readFileSync(menuPath));
+} catch (err) {
+  console.error('Could not load menu.json, starting with empty menu');
+}
+
+app.get('/api/menu', (req, res) => {
+  res.json(menu);
+});
+
+app.post('/api/order', (req, res) => {
+  const order = req.body;
+  console.log('Received order:', order);
+  res.json({ status: 'received' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- scaffold server and client for Santa Dicas PWA
- add express backend with menu and order endpoints
- implement simple offline-capable client
- document how to run the project

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683e6b38a3b48330b896953c231a67d9