### PR TITLE
Update service worker cache version

### DIFF
--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -1,9 +1,21 @@
-const CACHE_NAME = 'santadicas-cache-v1';
+const CACHE_NAME = 'santadicas-cache-v2';
 const urlsToCache = ['/', '/app.js', '/style.css'];
 
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(cacheNames =>
+      Promise.all(
+        cacheNames
+          .filter(name => name !== CACHE_NAME)
+          .map(name => caches.delete(name))
+      )
+    )
   );
 });
 


### PR DESCRIPTION
## Summary
- bump `CACHE_NAME` in `service-worker.js`
- clear outdated caches in new `activate` handler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867977f25d08330ab0bb80571ea2443